### PR TITLE
Allow configuring remote game server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
 1. ブラウザで `http://localhost:3000` を開きます。
 2. 最初の 2 クライアントが同じルームにマッチングされ、ゲームが開始されます。
 
+### 離れた友だちと遊ぶには？
+- サーバーをインターネット越しに公開している場合、クライアント URL に `?server=<WebSocket サーバー URL>` を付けると任意のサーバーへ接続できます。
+  - 例: `https://example.com?server=wss://example.com/game`
+- 静的ホスティングサービスなどで HTML を直接配信している場合も、サーバー URL を指定すればオンライン対戦が可能です。
+- JavaScript から直接指定したい場合は `window.GAME_SERVER_URL = "wss://example.com/game";` を設定してから `js/main.js` を読み込んでください。
+
 ## 開発モード
 変更のたびにサーバーを自動再起動したい場合は nodemon を使った開発モードを利用できます。
 ```bash

--- a/client/js/network.js
+++ b/client/js/network.js
@@ -1,5 +1,45 @@
 const RECONNECT_DELAY = 2000;
 
+function normalizeOverride(value) {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Allow a complete WebSocket URL. Append the default path if necessary.
+  if (/^wss?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      if (url.pathname === "/" || url.pathname === "") {
+        url.pathname = "/game";
+      }
+      return url.toString();
+    } catch (error) {
+      console.warn("Invalid WebSocket URL override", error);
+      return null;
+    }
+  }
+
+  // Treat the override as host (and optional path) without protocol.
+  const protocol = location.protocol === "https:" ? "wss" : "ws";
+  const sanitized = trimmed.replace(/^\/+/, "").replace(/\s+/g, "");
+  const needsPath = !sanitized.includes("/");
+  const path = needsPath ? "/game" : "";
+  return `${protocol}://${sanitized}${path}`;
+}
+
+function resolveWebSocketUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const override = window.GAME_SERVER_URL || params.get("server");
+  const normalized = normalizeOverride(override);
+  if (normalized) {
+    return normalized;
+  }
+
+  const protocol = location.protocol === "https:" ? "wss" : "ws";
+  const host = location.host || "localhost:3000";
+  return `${protocol}://${host}/game`;
+}
+
 export class NetworkClient {
   constructor({ onOpen, onClose, onError, onMessage }) {
     this.ws = null;
@@ -8,13 +48,12 @@ export class NetworkClient {
     this.onError = onError;
     this.onMessage = onMessage;
     this.shouldReconnect = true;
+    this.endpoint = resolveWebSocketUrl();
     this.connect();
   }
 
   connect() {
-    const protocol = location.protocol === "https:" ? "wss" : "ws";
-    const url = `${protocol}://${location.host}/game`;
-    this.ws = new WebSocket(url);
+    this.ws = new WebSocket(this.endpoint);
 
     this.ws.addEventListener("open", () => {
       this.onOpen?.();


### PR DESCRIPTION
## Summary
- allow overriding the WebSocket endpoint via query parameter or global config for remote play
- document how to specify a remote server when hosting the client separately
- add a gitignore entry for node_modules and common artifacts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68fdc37673bc832d94501c7fc88b1e0f